### PR TITLE
Accept all docker compose filenames on default (#138)

### DIFF
--- a/.github/workflows/__check-action.yml
+++ b/.github/workflows/__check-action.yml
@@ -29,6 +29,29 @@ jobs:
           docker compose -f ./test/docker-compose.yml ps | grep test-service-c-1 || (echo "Service service-c is not running" && exit 1)
           (docker compose -f ./test/docker-compose.yml ps | grep test-service-a-1 && echo "Unexpected service service-a is running" && exit 1) || true
 
+  test-action-with-yaml-compose-file:
+    runs-on: ubuntu-latest
+    name: Test with yaml (not yml) compose file
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: "Rename docker-compose.yml to docker-compose.yaml"
+        run: mv ./test/docker-compose.yml ./test/docker-compose.yaml
+
+      - name: Act
+        uses: ./
+        with:
+          services: |
+            service-b
+            service-c
+
+      - name: "Assert: docker-compose.yaml is used"
+        run: docker compose -f ./test/docker-compose.yaml ps
+
+        docker compose -f ./test/docker-compose.yaml ps | grep test-service-b-1 || (echo "Service service-b is not running" && exit 1)
+        docker compose -f ./test/docker-compose.yaml ps | grep test-service-c-1 || (echo "Service service-c is not running" && exit 1)
+        (docker compose -f ./test/docker-compose.yaml ps | grep test-service-a-1 && echo "Unexpected service service-a is running" && exit 1) || true
+
   test-action-with-down-flags:
     runs-on: ubuntu-latest
     name: Test compose action

--- a/action.yml
+++ b/action.yml
@@ -12,7 +12,11 @@ inputs:
   compose-file:
     description: "Path to compose file(s). It can be a list of files. It can be absolute or relative to the current working directory (cwd)."
     required: false
-    default: "./docker-compose.yml"
+    default: |
+      ./docker-compose.yml
+      ./docker-compose.yaml
+      ./compose.yml
+      ./compose.yaml
   services:
     description: "Services to perform docker compose up."
     required: false

--- a/src/services/input.service.test.ts
+++ b/src/services/input.service.test.ts
@@ -90,14 +90,22 @@ describe("InputService", () => {
         expect(inputs.composeFiles).toEqual(["file1", "file2"]);
       });
 
-      it("should throws an error when a compose file does not exist", () => {
+      it("should throws an error when no composeFiles input", () => {
+        getMultilineInputMock.mockReturnValue([]);
+
+        getInputMock.mockReturnValue("");
+
+        expect(() => service.getInputs()).toThrow("No compose files found");
+      });
+
+      it("should throw an error when all compose files do not exist", () => {
         getMultilineInputMock.mockImplementation((inputName) => {
           switch (inputName) {
             case InputNames.ComposeFile:
               return ["file1", "file2"];
             default:
               return [];
-          }
+              }
         });
 
         getInputMock.mockImplementation((inputName) => {
@@ -109,17 +117,7 @@ describe("InputService", () => {
           }
         });
 
-        existsSyncMock.mockImplementation((file) => file === "/current/working/directory/file1");
-
-        expect(() => service.getInputs()).toThrow(
-          'Compose file not found in "/current/working/directory/file2", "file2"'
-        );
-      });
-
-      it("should throws an error when no composeFiles input", () => {
-        getMultilineInputMock.mockReturnValue([]);
-
-        getInputMock.mockReturnValue("");
+        existsSyncMock.mockImplementation((file) => false);
 
         expect(() => service.getInputs()).toThrow("No compose files found");
       });

--- a/src/services/input.service.ts
+++ b/src/services/input.service.ts
@@ -62,7 +62,7 @@ export class InputService {
         }
       }
 
-      throw new Error(`Compose file not found in "${possiblePaths.join('", "')}"`);
+      return false;
     });
 
     if (!composeFiles.length) {


### PR DESCRIPTION
- Change `getComposeFiles` behavior to not throw an error if a compose file was not found (and only filter it out), and throw an error only if all give files were not found.
- Change the compose-file default to be all 4 docker compose filenames specified by [Docker's official documentation](https://docs.docker.com/compose/intro/compose-application-model/) . Because of the previous change, this will now cause the action to behave on default similarily to the `docker compose` command (in order to minimize confusion when using default parameters) - try to found files with all 4 possible names.
  -  One difference between this implementation and `docker compose`'s behavior that should be noted is that if multiple files exists (e.g `compose.yaml` and `docker-compose.yml`), the action will use both of them while `docker compose` will choose one file and has an order of preference.
- Updated tests accordingly